### PR TITLE
Security hardening and low-severity fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,27 @@ jobs:
       - name: make check
         run: make check
 
+  sanitizers:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/prepare
+      - name: autogen
+        run: ./autogen.sh
+      - name: configure (ASan + UBSan)
+        run: |
+          ./configure \
+            CFLAGS="-g -O1 -fsanitize=address,undefined -fno-omit-frame-pointer" \
+            CXXFLAGS="-g -O1 -std=c++14 -fsanitize=address,undefined -fno-omit-frame-pointer" \
+            LDFLAGS="-fsanitize=address,undefined"
+      - name: make
+        run: make
+      - name: make check (sanitized)
+        run: make check
+        env:
+          ASAN_OPTIONS: detect_leaks=0
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+
   integration:
     runs-on: ubuntu-latest
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -1,6 +1,13 @@
 ## No default includes
-DEFAULT_INCLUDES = 
-AM_CXXFLAGS = -std=c++14
+DEFAULT_INCLUDES =
+
+## Compiler/link hardening (issue #20). Applied on top of the user's CFLAGS.
+## FORTIFY_SOURCE needs an optimization level; the autoconf default is -O2.
+HARDENING_CFLAGS = -fstack-protector-strong -fstack-clash-protection -D_FORTIFY_SOURCE=2
+AM_CFLAGS = $(HARDENING_CFLAGS)
+AM_CXXFLAGS = -std=c++14 $(HARDENING_CFLAGS)
+## Full RELRO for every link target (libraries and the binary).
+AM_LDFLAGS = -Wl,-z,relro,-z,now
 
 minicrawlerincludedir = $(includedir)/libminicrawler-@MINICRAWLER_API_VERSION@/minicrawler
 minicrawlerinclude_HEADERS = src/url/minicrawler-url.h src/h/minicrawler.h
@@ -12,25 +19,26 @@ minicrawler_sources = src/main.c src/cli.c $(libminicrawler_sources)
 lib_LTLIBRARIES = libminicrawler/libminicrawler-url-@MINICRAWLER_API_VERSION@.la libminicrawler/libminicrawler-@MINICRAWLER_API_VERSION@.la
 
 libminicrawler_libminicrawler_url_@MINICRAWLER_API_VERSION@_la_SOURCES = $(libminicrawler_url_sources)
-libminicrawler_libminicrawler_url_@MINICRAWLER_API_VERSION@_la_LDFLAGS = -version-info $(MINICRAWLER_LT_VERSION)
+libminicrawler_libminicrawler_url_@MINICRAWLER_API_VERSION@_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(MINICRAWLER_LT_VERSION)
 libminicrawler_libminicrawler_url_@MINICRAWLER_API_VERSION@_la_CPPFLAGS = $(AM_CPPFLAGS) -DBUILDING_MCRAWLER
 libminicrawler_libminicrawler_url_@MINICRAWLER_API_VERSION@_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 
 libminicrawler_libminicrawler_@MINICRAWLER_API_VERSION@_la_SOURCES =  $(libminicrawler_sources)
-libminicrawler_libminicrawler_@MINICRAWLER_API_VERSION@_la_LDFLAGS = -version-info $(MINICRAWLER_LT_VERSION)
+libminicrawler_libminicrawler_@MINICRAWLER_API_VERSION@_la_LDFLAGS = $(AM_LDFLAGS) -version-info $(MINICRAWLER_LT_VERSION)
 libminicrawler_libminicrawler_@MINICRAWLER_API_VERSION@_la_CPPFLAGS = $(AM_CPPFLAGS) -DBUILDING_MCRAWLER
 libminicrawler_libminicrawler_@MINICRAWLER_API_VERSION@_la_CFLAGS = $(AM_CFLAGS) -fvisibility=hidden
 
 bin_PROGRAMS = minicrawler@MINICRAWLER_API_VERSION@
 
 minicrawler@MINICRAWLER_API_VERSION@_SOURCES = $(minicrawler_sources)
-minicrawler@MINICRAWLER_API_VERSION@_CFLAGS = $(AM_CFLAGS)
+minicrawler@MINICRAWLER_API_VERSION@_CFLAGS = $(AM_CFLAGS) -fPIE
+minicrawler@MINICRAWLER_API_VERSION@_LDFLAGS = $(AM_LDFLAGS) -pie
 
 check_PROGRAMS = test/url
 
 test_url_SOURCES = test/url.c test/json/json.c $(libminicrawler_url_sources)
 test_url_CFLAGS = $(AM_CFLAGS)
-test_url_LDFLAGS = -lm
+test_url_LDFLAGS = $(AM_LDFLAGS) -lm
 #test_url_LDADD = libminicrawler-url.la
 
 LOG_DRIVER = env AM_TAP_AWK='$(AWK)' $(SHELL) $(top_srcdir)/build-aux/tap-driver.sh

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ void main() {
          -6         resolve host to IPv6 address only
          -8         convert from page encoding to UTF-8
          -A STRING  custom user agent (max 255 bytes)
-         -b STRING  cookies in the netscape/mozilla file format (max 20 cookies)
+         -b STRING  cookies in the netscape/mozilla file format (max 25 cookies)
          -c         convert content to text format (with UTF-8 encoding)
          -DMILIS    set delay time in milliseconds when downloading more pages from the same IP (default is 100 ms)
          -g         accept gzip encoding

--- a/src/api.c
+++ b/src/api.c
@@ -36,6 +36,7 @@ void mcrawler_init_url(mcrawler_url *u, const char *url) {
  */
 void mcrawler_reset_url(mcrawler_url *u) {
 	reset_url(u);
+	u->redirect_limit = MAX_REDIRECTS;
 	u->state = MCURL_S_PARSEDURL;
 }
 

--- a/src/cli.c
+++ b/src/cli.c
@@ -19,7 +19,7 @@ void printusage()
 	         "         -6         resolve host to IPv6 address only\n"
 	         "         -8         convert from page encoding to UTF-8\n"
 	         "         -A STRING  custom user agent (max 255 bytes)\n"
-	         "         -b STRING  cookies in the netscape/mozilla file format (max 20 cookies)\n"
+	         "         -b STRING  cookies in the netscape/mozilla file format (max 25 cookies)\n"
 	         "         -c         convert content to text format (with UTF-8 encoding)\n"
 	         "         -DMILIS    set delay time in miliseconds when downloading more pages from the same IP (default is 100 ms)\n"
 	         "         -g         accept gzip encoding\n"
@@ -44,6 +44,16 @@ void printusage()
 }
 
 static int writehead = 0;
+
+/** Abort with a usage error if an option is missing its argument (i.e. it is
+ *  the last token on the command line). argv[argc] is NULL, so an unguarded
+ *  argv[t+1] would be a NULL dereference. */
+#define NEED_ARG(t) do { \
+	if ((t) + 1 >= argc) { \
+		fprintf(stderr, "minicrawler: option %s requires an argument\n", argv[t]); \
+		exit(1); \
+	} \
+} while (0)
 
 /** nacte url z prikazove radky do struktur
  */
@@ -77,9 +87,10 @@ void initurls(int argc, char *argv[], mcrawler_url **urls, mcrawler_settings *se
 		if(!strcmp(argv[t], "-l")) {options |= 1<<MCURL_OPT_NOT_FOLLOW_REDIRECTS; continue;}
 		if(!strncmp(argv[t], "-t", 2)) {settings->timeout = atoi(argv[t]+2); continue;}
 		if(!strncmp(argv[t], "-D", 2)) {settings->delay = atoi(argv[t]+2); continue;}
-		if(!strcmp(argv[t], "-w")) {SAFE_STRCPY(customheader, argv[t+1]); t++; continue;}
-		if(!strcmp(argv[t], "-A")) {str_replace(customagent, argv[t+1], "%version%", VERSION); t++; continue;}
+		if(!strcmp(argv[t], "-w")) {NEED_ARG(t); SAFE_STRCPY(customheader, argv[t+1]); t++; continue;}
+		if(!strcmp(argv[t], "-A")) {NEED_ARG(t); str_replace(customagent, argv[t+1], "%version%", VERSION); t++; continue;}
 		if(!strcmp(argv[t], "-b")) {
+			NEED_ARG(t);
 			p = argv[t+1];
 			while (p[0] != '\0' && ccnt < COOKIESTORAGESIZE) {
 				q = strchrnul(p, '\n');
@@ -95,13 +106,14 @@ void initurls(int argc, char *argv[], mcrawler_url **urls, mcrawler_settings *se
 			continue;
 		}
 		if(!strcmp(argv[t], "-6")) {options |= 1<<MCURL_OPT_IPV6; continue;}
-		if(!strcmp(argv[t], "-u")) {SAFE_STRCPY(username, argv[t+1]); t++; continue;}
+		if(!strcmp(argv[t], "-u")) {NEED_ARG(t); SAFE_STRCPY(username, argv[t+1]); t++; continue;}
 		if(!strncmp(argv[t], "-p", 2)) {SAFE_STRCPY(password, argv[t] + 2); continue;}
 		if(!strcmp(argv[t], "-2")) {options |= 1<<MCURL_OPT_DISABLE_HTTP2; continue;}
 		if(!strncmp(argv[t], "-m", 2)) {maxpagesize = atoi(argv[t]+2)*1024*1024UL; continue;}
 
 		// urloptions
 		if(!strcmp(argv[t], "-P")) {
+			NEED_ARG(t);
 			url->post = malloc(strlen(argv[t+1]) + 1);
 			url->postlen = strlen(argv[t+1]);
 			memcpy(url->post, argv[t+1], url->postlen);
@@ -109,13 +121,14 @@ void initurls(int argc, char *argv[], mcrawler_url **urls, mcrawler_settings *se
 			continue;
 		}
 		if(!strcmp(argv[t], "-C")) {
+			NEED_ARG(t);
 			if (customheader[0]) {
 				str_replace(url->customheader, customheader, "%", argv[t+1]);
 			}
 			t++;
 			continue;
 		}
-		if(!strcmp(argv[t], "-X")) {SAFE_STRCPY(url->method, argv[t+1]); t++; continue;}
+		if(!strcmp(argv[t], "-X")) {NEED_ARG(t); SAFE_STRCPY(url->method, argv[t+1]); t++; continue;}
 
 		// init url
 		mcrawler_init_url(url, argv[t]);

--- a/src/crawler.c
+++ b/src/crawler.c
@@ -738,7 +738,7 @@ static void opensocket(mcrawler_url *u)
 		}
 	} else {
 		set_atomic_int(&u->state, MCURL_S_HANDSHAKE);
-		set_atomic_int(&u->rw, 1<<MCURL_RW_WANT_WRITE | 1<<MCURL_RW_WANT_WRITE);
+		set_atomic_int(&u->rw, 1<<MCURL_RW_WANT_READ | 1<<MCURL_RW_WANT_WRITE);
 	}
 }
 

--- a/src/http1.c
+++ b/src/http1.c
@@ -99,7 +99,7 @@ int eatchunk(mcrawler_url *u) {
 	}
 
 	// čte velikost chunku
-	for (t=u->nextchunkedpos, i=0; buf[t] != '\r' && buf[t] != '\n' && t < buflen; t++) {
+	for (t=u->nextchunkedpos, i=0; t < buflen && buf[t] != '\r' && buf[t] != '\n'; t++) {
 		if (i < 9) {
 			hex[i++] = buf[t];
 		}

--- a/src/inflate.c
+++ b/src/inflate.c
@@ -31,7 +31,7 @@ int gunzip_buf(mcrawler_url *u) {
                 strcpy(u->error_msg, ERR_PREFIX "out of memory in init");
                 break;
             case Z_VERSION_ERROR:
-                sprintf(u->error_msg, ERR_PREFIX "incompatible zlib version", rc);
+                strcpy(u->error_msg, ERR_PREFIX "incompatible zlib version");
                 break;
             case Z_STREAM_ERROR: // -2
                 // parameters are invalid, such as a null pointer to the

--- a/src/memory.c
+++ b/src/memory.c
@@ -17,10 +17,10 @@ void mcrawler_cp_cookie(mcrawler_cookie *dst, const mcrawler_cookie *src) {
 	dst->domain = malloc(strlen(src->domain) + 1);
 	dst->path = malloc(strlen(src->path) + 1);
 
-	strcpy(dst->name, src->name);
-	strcpy(dst->value, src->value);
-	strcpy(dst->domain, src->domain);
-	strcpy(dst->path, src->path);
+	if (dst->name) strcpy(dst->name, src->name);
+	if (dst->value) strcpy(dst->value, src->value);
+	if (dst->domain) strcpy(dst->domain, src->domain);
+	if (dst->path) strcpy(dst->path, src->path);
 	dst->host_only = src->host_only;
 	dst->secure = src->secure;
 	dst->expires = src->expires;

--- a/src/url/parse.cc
+++ b/src/url/parse.cc
@@ -106,10 +106,14 @@ static void percent_decode(char *output, int *length, const char *input) {
 			// Let bytePoint be the two bytes after byte in input, decoded, and then interpreted as hexadecimal number.
 			char bytes[3] = {0, 0, 0};
 			strncpy(bytes, p, 2);
-			int r = sscanf(bytes, "%X", (unsigned int *)(output + outp));
+			// Decode into a full-width int, then store a single byte: writing
+			// through (unsigned int *)(output + outp) would clobber 3 extra
+			// bytes and is unaligned UB.
+			unsigned int bytePoint = 0;
+			int r = sscanf(bytes, "%X", &bytePoint);
 			// Append a byte whose value is bytePoint to output.
 			if (r) {
-				outp++;
+				output[outp++] = (char)bytePoint;
 			}
 			// Skip the next two bytes in input.
 			p += 2;
@@ -539,6 +543,13 @@ int mcrawler_url_parse_host(mcrawler_url_host* host, const char *input) {
 	if (domain_to_ascii(asciiDomain, 256, domain) == MCRAWLER_URL_FAILURE) {
 		// If asciiDomain is failure, return failure.
 		debugf("Host parsing failure (4) for %s\n", input);
+		return MCRAWLER_URL_FAILURE;
+	}
+	// Defense in depth: host->domain and the crawler's host[]/hostname[]
+	// buffers are all sized for at most 255 chars. domain_to_ascii already
+	// enforces this via the ICU capacity, but guard the invariant explicitly.
+	if (strlen(asciiDomain) > 255) {
+		debugf("Host parsing failure (asciiDomain too long) for %s\n", input);
 		return MCRAWLER_URL_FAILURE;
 	}
 	// If asciiDomain contains U+0000, U+0009, U+000A, U+000D, U+0020, "#",

--- a/test/fuzz_url.c
+++ b/test/fuzz_url.c
@@ -1,0 +1,52 @@
+/*
+ * libFuzzer harness for the WHATWG URL parser (libminicrawler-url).
+ *
+ * The URL parser is a primary attack surface: it parses fully untrusted input
+ * and its output guards a zero-margin invariant (host -> domain[256], see the
+ * security review / issue #20). This harness exercises parse + all getters +
+ * free so ASan/UBSan can catch OOB, UAF, leaks, and UB.
+ *
+ * Build (clang):
+ *   clang -g -O1 -std=c++14 -fsanitize=address,undefined,fuzzer \
+ *       test/fuzz_url.c src/url/parse.cc src/url/serialize.c \
+ *       src/url/api.c src/url/alloc.c -licuuc -o fuzz_url
+ *   ./fuzz_url -max_len=8192 corpus/
+ *
+ * Seed the corpus from test/urltestdata.json inputs for faster coverage.
+ */
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "../src/url/minicrawler-url.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+	// The parser expects a NUL-terminated C string.
+	char *input = (char *)malloc(size + 1);
+	if (!input) {
+		return 0;
+	}
+	memcpy(input, data, size);
+	input[size] = '\0';
+
+	mcrawler_url_url url;
+	if (mcrawler_url_parse(&url, input, NULL) == MCRAWLER_URL_SUCCESS) {
+		// Exercise every getter (each mallocs a serialized component) and
+		// free it, so the whole serialize path is fuzzed too.
+		free(mcrawler_url_get_href(&url));
+		free(mcrawler_url_get_protocol(&url));
+		free(mcrawler_url_get_username(&url));
+		free(mcrawler_url_get_password(&url));
+		free(mcrawler_url_get_hostname(&url, NULL));
+		free(mcrawler_url_get_host(&url, NULL));
+		free(mcrawler_url_get_port(&url));
+		free(mcrawler_url_get_pathname(&url));
+		free(mcrawler_url_get_search(&url));
+		free(mcrawler_url_get_hash(&url));
+		mcrawler_url_free_url(&url);
+	}
+
+	free(input);
+	return 0;
+}


### PR DESCRIPTION
Build hardening and a batch of low-severity correctness/safety fixes from a security review (tracked internally as issue #20).

**Verified:** clean build with the new hardening flags; **311/311** URL tests pass under both a normal and an **ASan+UBSan** build. Hardening confirmed in the binary (PIE, full RELRO/`BIND_NOW`, FORTIFY `__*_chk` symbols).

### Build hardening (`Makefile.am`)
`-fstack-protector-strong -fstack-clash-protection -D_FORTIFY_SOURCE=2`, full RELRO (`-Wl,-z,relro,-z,now`), and PIE for the binary.

### Code fixes
- `http1.c` — fix 1-byte OOB read in `eatchunk()` (bound check now precedes the `buf[t]` deref).
- `cli.c` — guard `-w/-A/-b/-u/-P/-C/-X` against a missing argument (NULL-deref on a trailing option).
- `crawler.c` — fix self-OR typo in `opensocket()` rw flags (`WANT_READ|WANT_WRITE`).
- `api.c` — reset `redirect_limit` in `mcrawler_reset_url()` on struct reuse.
- `url/parse.cc` — `percent_decode()` now stores a single byte (was a 4-byte unaligned write); explicit `asciiDomain` length guard.
- `inflate.c` — drop stray `sprintf` argument.
- `memory.c` — NULL-check allocations in `mcrawler_cp_cookie()`.

### Docs / CI / tooling
- README + CLI help: cookie limit is 25 (`COOKIESTORAGESIZE`), not 20.
- Add ASan+UBSan CI job.
- Add `test/fuzz_url.c` libFuzzer harness for the URL parser.